### PR TITLE
opening summary disabled keybinds

### DIFF
--- a/main.js
+++ b/main.js
@@ -919,7 +919,7 @@ async function main() {
 	let activeKeys = [];
 
 	window.addEventListener("keydown", (e) => {
-		if (document.activeElement != document.body) return;
+		// if (document.activeElement != document.body) return;
 		carousel = false;
 		if (!activeKeys.includes(e.key)) activeKeys.push(e.key);
 		if (/\d/.test(e.key)) {


### PR DESCRIPTION
Opening the 'summary' element would disable all keybinds. This wasn't too bad on its own and might have been intended, but a problem occurred when the summary was closed. It would still have focus and the keybinds would not work until select some of the text in the info div.