### PR TITLE
added key press for camera cycling, added note on loading cameras.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ touch (mobile)
 
 other
 - press 0-9 to switch to one of the pre-loaded camera views
+- press '-' or '+'key to cycle loaded cameras
 - press `p` to resume default animation
 - drag and drop .ply file to convert to .splat
+- drag and drop cameras.json to load cameras
 
 ## other features
 

--- a/index.html
+++ b/index.html
@@ -231,8 +231,10 @@ gamepad
 
 other
 - press 0-9 to switch to one of the pre-loaded camera views
+- press '-' or '+'key to cycle loaded cameras
 - press p to resume default animation
 - drag and drop .ply file to convert to .splat
+- drag and drop cameras.json to load cameras
 </div>
 
 		</details>

--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@ other
 			<span id="fps"></span>
 		</div>
 		<div id="caminfo">
-			<span id="camera"></span>
+			<span id="camid"></span>
 		</div>
 		<script src="main.js"></script>
 	</body>

--- a/index.html
+++ b/index.html
@@ -156,6 +156,12 @@
 				right: 10px;
 			}
 
+			#caminfo {
+				position: absolute;
+				top: 10px;
+				z-index: 999;
+				right: 10px;
+			}
 			#canvas {
 				display: block;
 				position: absolute;
@@ -262,6 +268,9 @@ other
 
 		<div id="quality">
 			<span id="fps"></span>
+		</div>
+		<div id="caminfo">
+			<span id="camera"></span>
 		</div>
 		<script src="main.js"></script>
 	</body>

--- a/main.js
+++ b/main.js
@@ -905,15 +905,25 @@ async function main() {
     };
 
     let activeKeys = [];
+	let currentCameraIndex = 0;
 
     window.addEventListener("keydown", (e) => {
         // if (document.activeElement != document.body) return;
         carousel = false;
         if (!activeKeys.includes(e.code)) activeKeys.push(e.code);
         if (/\d/.test(e.key)) {
-            camera = cameras[parseInt(e.key)];
+            currentCameraIndex = parseInt(e.key)
+            camera = cameras[currentCameraIndex];
             viewMatrix = getViewMatrix(camera);
         }
+		if (['-', '_'].includes(e.key)){
+			currentCameraIndex = (currentCameraIndex + cameras.length - 1) % cameras.length;
+			viewMatrix = getViewMatrix(cameras[currentCameraIndex]);
+		}
+		if (['+', '='].includes(e.key)){
+			currentCameraIndex = (currentCameraIndex + 1) % cameras.length;
+			viewMatrix = getViewMatrix(cameras[currentCameraIndex]);
+		}
         if (e.code == "KeyV") {
             location.hash =
                 "#" +

--- a/main.js
+++ b/main.js
@@ -184,6 +184,15 @@ function getViewMatrix(camera) {
     ].flat();
     return camToWorld;
 }
+// function translate4(a, x, y, z) {
+//     return [
+//         ...a.slice(0, 12),
+//         a[0] * x + a[4] * y + a[8] * z + a[12],
+//         a[1] * x + a[5] * y + a[9] * z + a[13],
+//         a[2] * x + a[6] * y + a[10] * z + a[14],
+//         a[3] * x + a[7] * y + a[11] * z + a[15],
+//     ];
+// }
 
 function multiply4(a, b) {
     return [
@@ -766,6 +775,8 @@ async function main() {
 
     const canvas = document.getElementById("canvas");
     const fps = document.getElementById("fps");
+    const camid = document.getElementById("camid");
+
     let projectionMatrix;
 
     const gl = canvas.getContext("webgl2", {
@@ -924,14 +935,17 @@ async function main() {
 			currentCameraIndex = (currentCameraIndex + 1) % cameras.length;
 			viewMatrix = getViewMatrix(cameras[currentCameraIndex]);
 		}
+        camid.innerText = "cam  " + currentCameraIndex;
         if (e.code == "KeyV") {
             location.hash =
                 "#" +
                 JSON.stringify(
                     viewMatrix.map((k) => Math.round(k * 100) / 100),
                 );
+                camid.innerText =""
         } else if (e.code === "KeyP") {
             carousel = true;
+            camid.innerText =""
         }
     });
     window.addEventListener("keyup", (e) => {
@@ -1337,6 +1351,9 @@ async function main() {
             document.getElementById("progress").style.display = "none";
         }
         fps.innerText = Math.round(avgFps) + " fps";
+        if (isNaN(currentCameraIndex)){
+            camid.innerText = "";
+        }
         lastFrame = now;
         requestAnimationFrame(frame);
     };


### PR DESCRIPTION
hey antimatter, great code, thanx for sharing. 

I looked at your code and noticed that dragging cameras.json into the scene would load them , so I added the note both to the readme and the context menu. And because one usually has more than 10 cameras I linked unused keys + and - ( as well as their upper/lower case for simplicity) to cycle cameras. 