### PR TITLE
fix sorting OOB issue

### DIFF
--- a/main.js
+++ b/main.js
@@ -450,7 +450,7 @@ function createWorker(self) {
         }
 
         // This is a 16 bit single-pass counting sort
-        let depthInv = (256 * 256) / (maxDepth - minDepth);
+        let depthInv = (256 * 256 - 1) / (maxDepth - minDepth);
         let counts0 = new Uint32Array(256 * 256);
         for (let i = 0; i < vertexCount; i++) {
             sizeList[i] = ((sizeList[i] - minDepth) * depthInv) | 0;


### PR DESCRIPTION
`depthInv` should normalize depths to `[0, 256*256-1]`. In the previous implementation, the largest value in `sizeList` can be `256*256`, which will lead to OOB issue by accessing `counts0[256*256]` and `starts0[256*256]`. The undefined value could be 0 and make the closest gaussians draw multiple times and skip some far-away gaussians.

---

This issue should be easily verified by using a `.ply` file with only two gaussians.
Following are two views with close viewpoint. One splat disappears and the other one draws twice.
![image](https://github.com/user-attachments/assets/f009e762-04fd-444d-806b-cffc83e522df)
![image](https://github.com/user-attachments/assets/23b752b7-7aa5-4620-b7da-e14b105134eb)
[debug.ply.zip](https://github.com/user-attachments/files/17843340/debug.ply.zip)
